### PR TITLE
Feature/rancher rke2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,13 @@ $ docker-machine create \
 - `--hetzner-server-type`: The type of the Hetzner Cloud server, see [Server Types API](hhttps://docs.hetzner.cloud/#server-types-get-all-server-types) for how to get a list (defaults to `cx11`).
 - `--hetzner-server-location`: The location to create the server in, see [Locations API](https://docs.hetzner.cloud/#locations-get-all-locations) for how to get a list.
 - `--hetzner-existing-key-path`: Use an existing (local) SSH key instead of generating a new keypair. If a remote key with a matching fingerprint exists, it will be used as if specified using `--hetzner-existing-key-id`, rather than uploading a new key.
-- `--hetzner-existing-key-id`: **requires `--hetzner-existing-key-path`**. Use an existing (remote) SSH key instead of uploading the imported key pair,
+- `--hetzner-existing-key-id`: Use an existing (remote) SSH key instead of uploading the imported key pair,
   see [SSH Keys API](https://docs.hetzner.cloud/#ssh-keys-get-all-ssh-keys) for how to get a list
 - `--hetzner-additional-key`: Upload an additional public key associated with the server, or associate an existing one with the same fingerprint. Can be specified multiple times.
 - `--hetzner-user-data`: Cloud-init based data, passed inline as-is.
 - `--hetzner-user-data-file`: Cloud-init based data, read from passed file.
-- `--hetzner-user-data-from-file`: DEPRECATED, use `--hetzner-user-data-file`. Read `--hetzner-user-data` as file name and use contents as user-data.
+- `--hetzner-user-data-from-file`: Read `--hetzner-user-data` as file name and use contents as user-data.
+- `--hetzner-additional-user-data`: Additional cloud-init based data, passed inline. This content will be merged into the user data YAML read from file. Useful to inject additional user data. If duplicate keys are existing in the base and additional data, they are getting combined, with the additional data _prepended_.
 - `--hetzner-volumes`: Volume IDs or names which should be attached to the server
 - `--hetzner-networks`: Network IDs or names which should be attached to the server private network interface
 - `--hetzner-use-private-network`: Use private network

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -69,30 +69,31 @@ const (
 	defaultImage = "ubuntu-20.04"
 	defaultType  = "cx11"
 
-	flagAPIToken          = "hetzner-api-token"
-	flagImage             = "hetzner-image"
-	flagImageID           = "hetzner-image-id"
-	flagImageArch         = "hetzner-image-arch"
-	flagType              = "hetzner-server-type"
-	flagLocation          = "hetzner-server-location"
-	flagExKeyID           = "hetzner-existing-key-id"
-	flagExKeyPath         = "hetzner-existing-key-path"
-	flagUserData          = "hetzner-user-data"
-	flagUserDataFile      = "hetzner-user-data-file"
-	flagVolumes           = "hetzner-volumes"
-	flagNetworks          = "hetzner-networks"
-	flagUsePrivateNetwork = "hetzner-use-private-network"
-	flagDisablePublic4    = "hetzner-disable-public-ipv4"
-	flagDisablePublic6    = "hetzner-disable-public-ipv6"
-	flagPrimary4          = "hetzner-primary-ipv4"
-	flagPrimary6          = "hetzner-primary-ipv6"
-	flagDisablePublic     = "hetzner-disable-public"
-	flagFirewalls         = "hetzner-firewalls"
-	flagAdditionalKeys    = "hetzner-additional-key"
-	flagServerLabel       = "hetzner-server-label"
-	flagKeyLabel          = "hetzner-key-label"
-	flagPlacementGroup    = "hetzner-placement-group"
-	flagAutoSpread        = "hetzner-auto-spread"
+	flagAPIToken           = "hetzner-api-token"
+	flagImage              = "hetzner-image"
+	flagImageID            = "hetzner-image-id"
+	flagImageArch          = "hetzner-image-arch"
+	flagType               = "hetzner-server-type"
+	flagLocation           = "hetzner-server-location"
+	flagExKeyID            = "hetzner-existing-key-id"
+	flagExKeyPath          = "hetzner-existing-key-path"
+	flagUserData           = "hetzner-user-data"
+	flagAdditionalUserData = "hetzner-additional-user-data"
+	flagUserDataFile       = "hetzner-user-data-file"
+	flagVolumes            = "hetzner-volumes"
+	flagNetworks           = "hetzner-networks"
+	flagUsePrivateNetwork  = "hetzner-use-private-network"
+	flagDisablePublic4     = "hetzner-disable-public-ipv4"
+	flagDisablePublic6     = "hetzner-disable-public-ipv6"
+	flagPrimary4           = "hetzner-primary-ipv4"
+	flagPrimary6           = "hetzner-primary-ipv6"
+	flagDisablePublic      = "hetzner-disable-public"
+	flagFirewalls          = "hetzner-firewalls"
+	flagAdditionalKeys     = "hetzner-additional-key"
+	flagServerLabel        = "hetzner-server-label"
+	flagKeyLabel           = "hetzner-key-label"
+	flagPlacementGroup     = "hetzner-placement-group"
+	flagAutoSpread         = "hetzner-auto-spread"
 
 	flagSshUser = "hetzner-ssh-user"
 	flagSshPort = "hetzner-ssh-port"
@@ -185,6 +186,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "HETZNER_USER_DATA",
 			Name:   flagUserData,
 			Usage:  "Cloud-init based user data (inline).",
+			Value:  "",
+		},
+		mcnflag.StringFlag{
+			EnvVar: "HETZNER_ADDITIONAL_USER_DATA",
+			Name:   flagAdditionalUserData,
+			Usage:  "Additional Cloud-init based user data (inline).",
 			Value:  "",
 		},
 		mcnflag.BoolFlag{

--- a/driver/ssh_keys.go
+++ b/driver/ssh_keys.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/machine/libmachine/mcnutils"
 	mcnssh "github.com/docker/machine/libmachine/ssh"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"golang.org/x/crypto/ssh"
 )
 
 func (d *Driver) setupExistingKey() error {
@@ -17,30 +16,30 @@ func (d *Driver) setupExistingKey() error {
 		return nil
 	}
 
-	if d.originalKey == "" {
-		return d.flagFailure("specifying an existing key ID requires the existing key path to be set as well")
-	}
+	// if d.originalKey == "" {
+	// 	return d.flagFailure("specifying an existing key ID requires the existing key path to be set as well")
+	// }
 
-	key, err := d.getKey()
+	_, err := d.getKey()
 	if err != nil {
 		return fmt.Errorf("could not get key: %w", err)
 	}
 
-	buf, err := os.ReadFile(d.originalKey + ".pub")
-	if err != nil {
-		return fmt.Errorf("could not read public key: %w", err)
-	}
+	// buf, err := os.ReadFile(d.originalKey + ".pub")
+	// if err != nil {
+	// 	return fmt.Errorf("could not read public key: %w", err)
+	// }
 
 	// Will also parse `ssh-rsa w309jwf0e39jf asdf` public keys
-	pubk, _, _, _, err := ssh.ParseAuthorizedKey(buf)
-	if err != nil {
-		return fmt.Errorf("could not parse authorized key: %w", err)
-	}
+	// pubk, _, _, _, err := ssh.ParseAuthorizedKey(buf)
+	// if err != nil {
+	// 	return fmt.Errorf("could not parse authorized key: %w", err)
+	// }
 
-	if key.Fingerprint != ssh.FingerprintLegacyMD5(pubk) &&
-		key.Fingerprint != ssh.FingerprintSHA256(pubk) {
-		return fmt.Errorf("remote key %d does not match local key %s", d.KeyID, d.originalKey)
-	}
+	// if key.Fingerprint != ssh.FingerprintLegacyMD5(pubk) &&
+	// 	key.Fingerprint != ssh.FingerprintSHA256(pubk) {
+	// 	return fmt.Errorf("remote key %d does not match local key %s", d.KeyID, d.originalKey)
+	// }
 
 	return nil
 }

--- a/driver/ssh_keys.go
+++ b/driver/ssh_keys.go
@@ -16,30 +16,10 @@ func (d *Driver) setupExistingKey() error {
 		return nil
 	}
 
-	// if d.originalKey == "" {
-	// 	return d.flagFailure("specifying an existing key ID requires the existing key path to be set as well")
-	// }
-
 	_, err := d.getKey()
 	if err != nil {
 		return fmt.Errorf("could not get key: %w", err)
 	}
-
-	// buf, err := os.ReadFile(d.originalKey + ".pub")
-	// if err != nil {
-	// 	return fmt.Errorf("could not read public key: %w", err)
-	// }
-
-	// Will also parse `ssh-rsa w309jwf0e39jf asdf` public keys
-	// pubk, _, _, _, err := ssh.ParseAuthorizedKey(buf)
-	// if err != nil {
-	// 	return fmt.Errorf("could not parse authorized key: %w", err)
-	// }
-
-	// if key.Fingerprint != ssh.FingerprintLegacyMD5(pubk) &&
-	// 	key.Fingerprint != ssh.FingerprintSHA256(pubk) {
-	// 	return fmt.Errorf("remote key %d does not match local key %s", d.KeyID, d.originalKey)
-	// }
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,5 @@ require (
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Add compatibility to RKE2 cluster creation via Rancher, by:

- Allowing to reference existing SSH keys by ID, without needing to provide the original key file
- De-deprecating the `hetzner-user-data-from-file` flag, to support the Rancher default flow of injecting the user data file path into the user-data flag
- Introducing the `hetzner-additional-user-data` that performs an ordered YAML-merge with the Rancher-provided configuration file and additionally provided inline user-data